### PR TITLE
Indexing functions accept degrees, not radians

### DIFF
--- a/h3_functions/h3_indexing.cpp
+++ b/h3_functions/h3_indexing.cpp
@@ -7,14 +7,14 @@ static void LatLngToCellFunction(DataChunk &args, ExpressionState &state, Vector
 	auto &inputs = args.data[0];
 	auto &inputs2 = args.data[1];
 	auto &inputs3 = args.data[2];
-	TernaryExecutor::Execute<double, double, int, H3Index>(inputs, inputs2, inputs3, result, args.size(),
-	                                                       [&](double lat, double lng, int res) {
-		                                                       H3Index cell;
-		                                                       LatLng latLng = {.lat = lat, .lng = lng};
-		                                                       H3Error err = latLngToCell(&latLng, res, &cell);
-		                                                       ThrowH3Error(err);
-		                                                       return cell;
-	                                                       });
+	TernaryExecutor::Execute<double, double, int, H3Index>(
+	    inputs, inputs2, inputs3, result, args.size(), [&](double lat, double lng, int res) {
+		    H3Index cell;
+		    LatLng latLng = {.lat = degsToRads(lat), .lng = degsToRads(lng)};
+		    H3Error err = latLngToCell(&latLng, res, &cell);
+		    ThrowH3Error(err);
+		    return cell;
+	    });
 }
 
 static void CellToLatFunction(DataChunk &args, ExpressionState &state, Vector &result) {

--- a/test/h3/h3_functions.test
+++ b/test/h3/h3_functions.test
@@ -25,3 +25,8 @@ query II
 SELECT h3_h3_to_string(cast(10000000000000000 as ubigint)), h3_h3_to_string(cast(1 as ubigint))
 ----
 2386f26fc10000	1
+
+query I
+SELECT printf('%x', h3_latlng_to_cell(37.7752702151959, -122.418307270836, 9)::bigint);
+----
+8928308280fffff


### PR DESCRIPTION
Fixes #13. The convention for H3 bindings is to accept degrees, not radians (as accepted by the underlying C library). Thanks @marklit for reporting this.