### PR TITLE
unindexing functions should return degrees

### DIFF
--- a/h3_functions/h3_indexing.cpp
+++ b/h3_functions/h3_indexing.cpp
@@ -23,7 +23,7 @@ static void CellToLatFunction(DataChunk &args, ExpressionState &state, Vector &r
 		LatLng latLng = {.lat = 0, .lng = 0};
 		H3Error err = cellToLatLng(cell, &latLng);
 		ThrowH3Error(err);
-		return latLng.lat;
+		return radsToDegs(latLng.lat);
 	});
 }
 
@@ -33,7 +33,7 @@ static void CellToLngFunction(DataChunk &args, ExpressionState &state, Vector &r
 		LatLng latLng = {.lat = 0, .lng = 0};
 		H3Error err = cellToLatLng(cell, &latLng);
 		ThrowH3Error(err);
-		return latLng.lng;
+		return radsToDegs(latLng.lng);
 	});
 }
 

--- a/test/h3/h3_functions.test
+++ b/test/h3/h3_functions.test
@@ -30,3 +30,8 @@ query I
 SELECT printf('%x', h3_latlng_to_cell(37.7752702151959, -122.418307270836, 9)::bigint);
 ----
 8928308280fffff
+
+query II
+SELECT h3_cell_to_lat(h3_string_to_h3('85283473fffffff')), h3_cell_to_lng(h3_string_to_h3('85283473fffffff'))
+----
+37.34579337536848	-121.9763759725512


### PR DESCRIPTION
Fixes #10. Thanks @havspect for reporting this issue. As with #14, the "un"indexing functions should return degrees.