### PR TITLE
undo caching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,13 +50,6 @@ jobs:
     - name: Check CMake
       run: cmake --version
 
-    - name: Cache DuckDB build
-      id: cache-duckdb-build
-      uses: actions/cache@v3
-      with:
-        path: ./duckdb/build
-        key: ${{ runner.os }}-duckdb
-
     - name: Build
       run: CMAKE_BUILD_PARALLEL_LEVEL=4 make release duckdb_release
 
@@ -88,13 +81,6 @@ jobs:
       run: |
         git submodule init
         git submodule update
-
-    - name: Cache DuckDB build
-      id: cache-duckdb-build
-      uses: actions/cache@v3
-      with:
-        path: ./duckdb/build
-        key: ${{ runner.os }}-duckdb
 
     - name: Build
       run: |


### PR DESCRIPTION
It doesn't appear this caching strategy is speeding up builds, so remove it for now