### PR TITLE
Remove formatting by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 set(TARGET_NAME h3ext)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
-
+set(ENABLE_LINTING FALSE)
 project(${TARGET_NAME})
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -68,7 +68,7 @@ install(
   LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
   ARCHIVE DESTINATION "${INSTALL_LIB_DIR}")
 
-
+function(format_code)
 # Automatic code formatting
 # Give preference to clang-format-9
 find_program(CLANG_FORMAT_PATH NAMES clang-format-9 clang-format)
@@ -90,4 +90,9 @@ if(ENABLE_FORMAT)
 elseif(NOT CLANG_FORMAT_PATH)
     message(WARNING "clang-format was not detected, "
                     "so automatic source code reformatting is disabled")
+endif()
+endfunction()
+
+if (ENABLE_LINTING)
+  format_code()
 endif()


### PR DESCRIPTION
While cross compiling (in particular to duckdb-wasm) linter does fail, so having some kind of escape hatch would be nice.
It also seems to me that it's somehow wasteful to iterate those check on every build. Would it make sense to have either them turned off by default (both for this and for the underlying library)?

Would it be possible to have this turned off by default ? Or alternatively having ENABLE_LINTING set to TRUE (so keeping same behaviour) but at least it becomes possible to opt-out?

Thanks!