### PR TITLE
rename to h3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
     with:
       duckdb_version: v1.0.0
-      extension_name: h3ext
+      extension_name: h3
       exclude_archs: "windows_amd64_rtools"
 
   duckdb-stable-deploy:
@@ -27,7 +27,7 @@ jobs:
     secrets: inherit
     with:
       duckdb_version: v1.0.0
-      extension_name: h3ext
+      extension_name: h3
       exclude_archs: "windows_amd64_rtools"
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.12)
-set(TARGET_NAME h3ext)
+set(TARGET_NAME h3)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)
 
@@ -51,7 +51,7 @@ add_subdirectory(h3)
 set(BUILD_SHARED_LIBS ON)
 
 set(EXTENSION_SOURCES
-    src/h3ext_extension.cpp
+    src/h3_extension.cpp
     src/h3_common.cpp
     src/h3_indexing.cpp
     src/h3_inspection.cpp
@@ -62,7 +62,7 @@ set(EXTENSION_SOURCES
     src/h3_misc.cpp
     src/h3_regions.cpp)
 set(LIB_HEADER_FILES src/include/h3_common.hpp src/include/h3_functions.hpp
-                     src/include/h3ext_extension.hpp)
+                     src/include/h3_extension.hpp)
 set(ALL_SOURCE_FILES ${EXTENSION_SOURCES} ${LIB_HEADER_FILES})
 
 add_library(${EXTENSION_NAME} STATIC ${EXTENSION_SOURCES})

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # Configuration of extension
-EXT_NAME=h3ext
+EXT_NAME=h3
 EXT_CONFIG=${PROJ_DIR}extension_config.cmake
 
 # Include the Makefile from extension-ci-tools

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ duckdb -unsigned
 
 Load the extension:
 ```SQL
-INSTALL h3ext FROM 'https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev';
-LOAD h3ext;
+INSTALL h3 FROM 'https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev';
+LOAD h3;
 ```
 
 Test running an H3 function:
@@ -30,7 +30,7 @@ SELECT h3_cell_to_latlng(586265647244115967);
 
 ## Download
 
-If you want to directly download the latest version of the extension: [Linux AMD64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/linux_amd64/h3ext.duckdb_extension.gz) [Linux AMD64 GCC4](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/linux_amd64_gcc4/h3ext.duckdb_extension.gz) [Linux Arm64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/linux_arm64/h3ext.duckdb_extension.gz) [OSX AMD64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/osx_amd64/h3ext.duckdb_extension.gz) [OSX Arm64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/osx_arm64/h3ext.duckdb_extension.gz) [wasm eh](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/wasm_eh/h3ext.duckdb_extension.wasm) [wasm mvp](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/wasm_mvp/h3ext.duckdb_extension.wasm) [wasm threads](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/wasm_threads/h3ext.duckdb_extension.wasm) [Windows AMD64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/windows_amd64/h3ext.duckdb_extension.gz)
+If you want to directly download the latest version of the extension: [Linux AMD64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/linux_amd64/h3.duckdb_extension.gz) [Linux AMD64 GCC4](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/linux_amd64_gcc4/h3.duckdb_extension.gz) [Linux Arm64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/linux_arm64/h3.duckdb_extension.gz) [OSX AMD64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/osx_amd64/h3.duckdb_extension.gz) [OSX Arm64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/osx_arm64/h3.duckdb_extension.gz) [wasm eh](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/wasm_eh/h3.duckdb_extension.wasm) [wasm mvp](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/wasm_mvp/h3.duckdb_extension.wasm) [wasm threads](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/wasm_threads/h3.duckdb_extension.wasm) [Windows AMD64](https://pub-cc26a6fd5d8240078bd0c2e0623393a5.r2.dev/v1.0.0/windows_amd64/h3.duckdb_extension.gz)
 
 # Implemented functions
 
@@ -131,7 +131,7 @@ To run, run the bundled `duckdb` shell:
 Load the extension:
 
 ```SQL
-load 'build/release/extension/h3ext/h3ext.duckdb_extension';
+load 'build/release/extension/h3/h3.duckdb_extension';
 ```
 
 To run tests:

--- a/extension_config.cmake
+++ b/extension_config.cmake
@@ -1,7 +1,7 @@
 # This file is included by DuckDB's build system. It specifies which extension to load
 
 # Extension from this repo
-duckdb_extension_load(h3ext
+duckdb_extension_load(h3
     SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}
     LOAD_TESTS
 )

--- a/src/h3_extension.cpp
+++ b/src/h3_extension.cpp
@@ -1,5 +1,5 @@
 #define DUCKDB_EXTENSION_MAIN
-#include "h3ext_extension.hpp"
+#include "h3_extension.hpp"
 
 #include "duckdb/catalog/catalog_entry/macro_catalog_entry.hpp"
 #include "duckdb/catalog/default/default_functions.hpp"
@@ -11,7 +11,7 @@
 
 namespace duckdb {
 
-void H3extExtension::Load(DuckDB &db) {
+void H3Extension::Load(DuckDB &db) {
   Connection con(db);
   con.BeginTransaction();
 
@@ -23,18 +23,18 @@ void H3extExtension::Load(DuckDB &db) {
   con.Commit();
 }
 
-std::string H3extExtension::Name() { return "h3ext"; }
+std::string H3Extension::Name() { return "h3"; }
 
 } // namespace duckdb
 
 extern "C" {
 
-DUCKDB_EXTENSION_API void h3ext_init(duckdb::DatabaseInstance &db) {
+DUCKDB_EXTENSION_API void h3_init(duckdb::DatabaseInstance &db) {
   duckdb::DuckDB db_wrapper(db);
-  db_wrapper.LoadExtension<duckdb::H3extExtension>();
+  db_wrapper.LoadExtension<duckdb::H3Extension>();
 }
 
-DUCKDB_EXTENSION_API const char *h3ext_version() {
+DUCKDB_EXTENSION_API const char *h3_version() {
   return duckdb::DuckDB::LibraryVersion();
 }
 }

--- a/src/include/h3_extension.hpp
+++ b/src/include/h3_extension.hpp
@@ -1,7 +1,7 @@
 //===----------------------------------------------------------------------===//
 //                         DuckDB
 //
-// h3ext_extension.hpp
+// h3_extension.hpp
 //
 //
 //===----------------------------------------------------------------------===//
@@ -12,7 +12,7 @@
 
 namespace duckdb {
 
-class H3extExtension : public Extension {
+class H3Extension : public Extension {
 public:
   void Load(DuckDB &db) override;
   std::string Name() override;

--- a/test/sql/h3/h3_functions.test
+++ b/test/sql/h3/h3_functions.test
@@ -1,4 +1,4 @@
-require h3ext
+require h3
 
 query I
 SELECT h3_latlng_to_cell(0, 0, 1);

--- a/test/sql/h3/h3_functions_directededge.test
+++ b/test/sql/h3/h3_functions_directededge.test
@@ -1,4 +1,4 @@
-require h3ext
+require h3
 
 query I
 SELECT h3_is_valid_directed_edge('2222597fffffffff');

--- a/test/sql/h3/h3_functions_hierarchy.test
+++ b/test/sql/h3/h3_functions_hierarchy.test
@@ -1,4 +1,4 @@
-require h3ext
+require h3
 
 query I
 SELECT h3_cell_to_parent(cast(586265647244115967 as ubigint), 1);

--- a/test/sql/h3/h3_functions_indexing.test
+++ b/test/sql/h3/h3_functions_indexing.test
@@ -1,4 +1,4 @@
-require h3ext
+require h3
 
 query I
 SELECT h3_latlng_to_cell(0, 0, -1);

--- a/test/sql/h3/h3_functions_inspection.test
+++ b/test/sql/h3/h3_functions_inspection.test
@@ -1,4 +1,4 @@
-require h3ext
+require h3
 
 query I
 SELECT h3_get_resolution(cast(586265647244115967 as ubigint));

--- a/test/sql/h3/h3_functions_misc.test
+++ b/test/sql/h3/h3_functions_misc.test
@@ -1,4 +1,4 @@
-require h3ext
+require h3
 
 query I
 SELECT h3_get_hexagon_area_avg(0, 'km^2');

--- a/test/sql/h3/h3_functions_regions.test
+++ b/test/sql/h3/h3_functions_regions.test
@@ -1,4 +1,4 @@
-require h3ext
+require h3
 
 query I
 select h3_cells_to_multi_polygon_wkt([586265647244115967::ubigint, 586260699441790975::ubigint, 586244756523188223::ubigint, 586245306279002111::ubigint, 586266196999929855::ubigint, 586264547732488191::ubigint, 586267846267371519::ubigint])

--- a/test/sql/h3/h3_functions_traversal.test
+++ b/test/sql/h3/h3_functions_traversal.test
@@ -1,4 +1,4 @@
-require h3ext
+require h3
 
 query I
 select h3_grid_disk(586265647244115967::ubigint, 1);

--- a/test/sql/h3/h3_functions_vertex.test
+++ b/test/sql/h3/h3_functions_vertex.test
@@ -1,4 +1,4 @@
-require h3ext
+require h3
 
 query I
 SELECT h3_is_valid_vertex('2222597fffffffff');

--- a/test/sql/h3/h3_parquet.test
+++ b/test/sql/h3/h3_parquet.test
@@ -1,6 +1,6 @@
 require parquet
 
-require h3ext
+require h3
 
 query I
 SELECT * from read_parquet('test/data/simple.parquet');


### PR DESCRIPTION
Rename the extension to just `h3`, dropping the `ext` part which was a holdover from figuring out the cmake and build process.