### PR TITLE
add h3_version function

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ one to use. The unsigned and signed APIs are identical. Many functions also supp
 | `h3_great_circle_distance` | | Compute the great circle distance between two points (haversine)
 | `h3_cells_to_multi_polygon_wkt` | [v](#fv) | Convert a set of cells to multipolygon WKT
 | `h3_polygon_wkt_to_cells` | [u](#fu) | Convert polygon WKT to a set of cells
+| `h3_version` | | Get the version of the H3 library
 
 ### Notes
 

--- a/src/h3_misc.cpp
+++ b/src/h3_misc.cpp
@@ -271,6 +271,14 @@ static void GreatCircleDistanceFunction(DataChunk &args, ExpressionState &state,
   }
 }
 
+static void VersionFunction(DataChunk &args, ExpressionState &state,
+                                        Vector &result) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    auto str = StringUtil::Format("%d.%d.%d", H3_VERSION_MAJOR, H3_VERSION_MINOR, H3_VERSION_PATCH);
+    string_t versionStr = string_t(strdup(str.c_str()), str.size());
+    result.SetValue(0, StringVector::AddString(result, versionStr));
+}
+
 CreateScalarFunctionInfo H3Functions::GetGetHexagonAreaAvgFunction() {
   return CreateScalarFunctionInfo(ScalarFunction(
       "h3_get_hexagon_area_avg", {LogicalType::INTEGER, LogicalType::VARCHAR},
@@ -332,6 +340,13 @@ CreateScalarFunctionInfo H3Functions::GetGreatCircleDistanceFunction() {
       {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE,
        LogicalType::DOUBLE, LogicalType::VARCHAR},
       LogicalType::DOUBLE, GreatCircleDistanceFunction));
+}
+
+CreateScalarFunctionInfo H3Functions::GetVersionFunctions() {
+  return CreateScalarFunctionInfo(ScalarFunction(
+      "h3_version",
+      {},
+      LogicalType::VARCHAR, VersionFunction));
 }
 
 } // namespace duckdb

--- a/src/include/h3_functions.hpp
+++ b/src/include/h3_functions.hpp
@@ -82,6 +82,7 @@ public:
     functions.push_back(GetGetRes0CellsFunction());
     functions.push_back(GetGetPentagonsFunction());
     functions.push_back(GetGreatCircleDistanceFunction());
+    functions.push_back(GetVersionFunctions());
 
     // Regions
     functions.push_back(GetCellsToMultiPolygonWktFunction());
@@ -156,6 +157,7 @@ private:
   static CreateScalarFunctionInfo GetGetRes0CellsFunction();
   static CreateScalarFunctionInfo GetGetPentagonsFunction();
   static CreateScalarFunctionInfo GetGreatCircleDistanceFunction();
+  static CreateScalarFunctionInfo GetVersionFunctions();
 
   // Regions
   static CreateScalarFunctionInfo GetCellsToMultiPolygonWktFunction();

--- a/test/sql/h3/h3_functions_misc.test
+++ b/test/sql/h3/h3_functions_misc.test
@@ -159,3 +159,8 @@ query I
 SELECT h3_great_circle_distance(5, 5, -15, -15, NULL)
 ----
 NULL
+
+query I
+SELECT h3_version()
+----
+4.1.0


### PR DESCRIPTION
There may be some way of adding this directly to the displayed extension description in DuckDB - if so, maybe it'd be better to use that, although an application would have a harder time querying it. This is patterned off of https://uber.github.io/h3-py/api_verbose.html#h3.versions