### PR TITLE
test adding extension description

### DIFF
--- a/src/h3_extension.cpp
+++ b/src/h3_extension.cpp
@@ -1,4 +1,5 @@
 #define DUCKDB_EXTENSION_MAIN
+#include "h3_common.hpp"
 #include "h3_extension.hpp"
 
 #include "duckdb/catalog/catalog_entry/macro_catalog_entry.hpp"
@@ -21,6 +22,11 @@ void H3Extension::Load(DuckDB &db) {
   }
 
   con.Commit();
+
+  std::string description = StringUtil::Format(
+      "Hierarchical hexagonal geospatial indexing system (v%d.%d.%d)",
+      H3_VERSION_MAJOR, H3_VERSION_MINOR, H3_VERSION_PATCH);
+  db.instance->SetExtensionDescription("h3", description);
 }
 
 std::string H3Extension::Name() { return "h3"; }


### PR DESCRIPTION
For use with https://github.com/duckdb/duckdb/compare/main...isaacbrodsky:duckdb:loaded-extensions-description?expand=1

```
D select extension_name, description from duckdb_extensions() where extension_name = 'h3';
┌────────────────┬────────────────────────────────────────────────────────────┐
│ extension_name │                        description                         │
│    varchar     │                          varchar                           │
├────────────────┼────────────────────────────────────────────────────────────┤
│ h3             │ Hierarchical hexagonal geospatial indexing system (v4.1.0) │
└────────────────┴────────────────────────────────────────────────────────────┘
```