### PR TITLE
Bump cmake_minimum_required(VERSION 3.5...3.29)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5...3.29)
 set(TARGET_NAME h3)
 set(EXTENSION_NAME ${TARGET_NAME}_extension)
 set(LOADABLE_EXTENSION_NAME ${TARGET_NAME}_loadable_extension)


### PR DESCRIPTION
This fix compilation with newer CMake (4.0.0) that require at least 3.5.