### PR TITLE
Dynamically set vector to constant whenever possible

### DIFF
--- a/src/h3_common.cpp
+++ b/src/h3_common.cpp
@@ -1,5 +1,8 @@
 #include "h3_common.hpp"
 
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+
 namespace duckdb {
 
 void ThrowH3Error(H3Error err) {

--- a/src/h3_directededge.cpp
+++ b/src/h3_directededge.cpp
@@ -409,17 +409,17 @@ CreateScalarFunctionInfo H3Functions::GetDirectedEdgeToCellsFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
                                    DirectedEdgeToCellsFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
                                    DirectedEdgeToCellsFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
                                    DirectedEdgeToCellsVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
@@ -429,17 +429,17 @@ CreateScalarFunctionInfo H3Functions::GetOriginToDirectedEdgesFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
                                    OriginToDirectedEdgesFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
                                    OriginToDirectedEdgesFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
                                    OriginToDirectedEdgesVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }

--- a/src/h3_directededge.cpp
+++ b/src/h3_directededge.cpp
@@ -359,8 +359,7 @@ struct DirectedEdgeToBoundaryOperator {
       }
       str += "))";
 
-      string_t strAsStr = string_t(strdup(str.c_str()), str.size());
-      return StringVector::AddString(result, strAsStr);
+      return StringVector::AddString(result, str);
     }
   }
 };

--- a/src/h3_directededge.cpp
+++ b/src/h3_directededge.cpp
@@ -399,13 +399,19 @@ CreateScalarFunctionInfo H3Functions::GetDirectedEdgeToCellsFunction() {
   ScalarFunctionSet funcs("h3_directed_edge_to_cells");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   DirectedEdgeToCellsFunction));
+                                   DirectedEdgeToCellsFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   DirectedEdgeToCellsFunction));
+                                   DirectedEdgeToCellsFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   DirectedEdgeToCellsVarcharFunction));
+                                   DirectedEdgeToCellsVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -413,13 +419,19 @@ CreateScalarFunctionInfo H3Functions::GetOriginToDirectedEdgesFunction() {
   ScalarFunctionSet funcs("h3_origin_to_directed_edges");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   OriginToDirectedEdgesFunction));
+                                   OriginToDirectedEdgesFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   OriginToDirectedEdgesFunction));
+                                   OriginToDirectedEdgesFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   OriginToDirectedEdgesVarcharFunction));
+                                   OriginToDirectedEdgesVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_directededge.cpp
+++ b/src/h3_directededge.cpp
@@ -23,6 +23,9 @@ static void DirectedEdgeToCellsFunction(DataChunk &args, ExpressionState &state,
       result_data[i].length = 2;
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -58,6 +61,9 @@ static void DirectedEdgeToCellsVarcharFunction(DataChunk &args,
       }
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -88,6 +94,9 @@ static void OriginToDirectedEdgesFunction(DataChunk &args,
 
       result_data[i].length = actual;
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -128,6 +137,9 @@ static void OriginToDirectedEdgesVarcharFunction(DataChunk &args,
         result_data[i].length = actual;
       }
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -408,19 +420,13 @@ CreateScalarFunctionInfo H3Functions::GetDirectedEdgeToCellsFunction() {
   ScalarFunctionSet funcs("h3_directed_edge_to_cells");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   DirectedEdgeToCellsFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   DirectedEdgeToCellsFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   DirectedEdgeToCellsFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   DirectedEdgeToCellsFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   DirectedEdgeToCellsVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   DirectedEdgeToCellsVarcharFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -428,19 +434,13 @@ CreateScalarFunctionInfo H3Functions::GetOriginToDirectedEdgesFunction() {
   ScalarFunctionSet funcs("h3_origin_to_directed_edges");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   OriginToDirectedEdgesFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   OriginToDirectedEdgesFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   OriginToDirectedEdgesFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   OriginToDirectedEdgesFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   OriginToDirectedEdgesVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   OriginToDirectedEdgesVarcharFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_directededge.cpp
+++ b/src/h3_directededge.cpp
@@ -339,59 +339,69 @@ static void IsValidDirectedEdgeFunction(DataChunk &args, ExpressionState &state,
       [&](H3Index input) { return bool(isValidDirectedEdge(input)); });
 }
 
-struct DirectedEdgeToBoundaryOperator {
-  template <class INPUT_TYPE, class RESULT_TYPE>
-  static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-    CellBoundary boundary;
-    H3Error err = directedEdgeToBoundary(input, &boundary);
-
-    if (err) {
-      // TODO: Is it possible to return null here instead?
-      return StringVector::EmptyString(result, 0);
-    } else {
-      std::string str = "LINESTRING ((";
-      for (int i = 0; i <= boundary.numVerts; i++) {
-        std::string sep = (i == 0) ? "" : ", ";
-        int vertIndex = (i == boundary.numVerts) ? 0 : i;
-        str += StringUtil::Format("%s%f %f", sep,
-                                  radsToDegs(boundary.verts[vertIndex].lng),
-                                  radsToDegs(boundary.verts[vertIndex].lat));
-      }
-      str += "))";
-
-      return StringVector::AddString(result, str);
-    }
-  }
-};
-
 static void DirectedEdgeToBoundaryWktFunction(DataChunk &args,
                                               ExpressionState &state,
                                               Vector &result) {
-  UnaryExecutor::ExecuteString<uint64_t, string_t,
-                               DirectedEdgeToBoundaryOperator>(
-      args.data[0], result, args.size());
-}
+  auto &inputs = args.data[0];
+  UnaryExecutor::ExecuteWithNulls<uint64_t, string_t>(
+      inputs, result, args.size(),
+      [&](uint64_t input, ValidityMask &mask, idx_t idx) {
+        CellBoundary boundary;
+        H3Error err = directedEdgeToBoundary(input, &boundary);
 
-struct DirectedEdgeToBoundaryVarcharOperator {
-  template <class INPUT_TYPE, class RESULT_TYPE>
-  static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-    H3Index h;
-    H3Error err = stringToH3(input.GetString().c_str(), &h);
-    if (err) {
-      return StringVector::EmptyString(result, 0);
-    } else {
-      return DirectedEdgeToBoundaryOperator().Operation<H3Index, RESULT_TYPE>(
-          h, result);
-    }
-  }
-};
+        if (err) {
+          mask.SetInvalid(idx);
+          return StringVector::EmptyString(result, 0);
+        } else {
+          std::string str = "LINESTRING ((";
+          for (int i = 0; i <= boundary.numVerts; i++) {
+            std::string sep = (i == 0) ? "" : ", ";
+            int vertIndex = (i == boundary.numVerts) ? 0 : i;
+            str += StringUtil::Format("%s%f %f", sep,
+                                      radsToDegs(boundary.verts[vertIndex].lng),
+                                      radsToDegs(boundary.verts[vertIndex].lat));
+          }
+          str += "))";
+
+          return StringVector::AddString(result, str);
+        }
+      });
+}
 
 static void DirectedEdgeToBoundaryWktVarcharFunction(DataChunk &args,
                                                      ExpressionState &state,
                                                      Vector &result) {
-  UnaryExecutor::ExecuteString<string_t, string_t,
-                               DirectedEdgeToBoundaryVarcharOperator>(
-      args.data[0], result, args.size());
+  auto &inputs = args.data[0];
+  UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
+      inputs, result, args.size(),
+      [&](string_t input, ValidityMask &mask, idx_t idx) {
+        H3Index h;
+        H3Error err = stringToH3(input.GetString().c_str(), &h);
+        if (err) {
+          mask.SetInvalid(idx);
+          return StringVector::EmptyString(result, 0);
+        } else {
+          CellBoundary boundary;
+          H3Error err = directedEdgeToBoundary(h, &boundary);
+
+          if (err) {
+            mask.SetInvalid(idx);
+            return StringVector::EmptyString(result, 0);
+          } else {
+            std::string str = "LINESTRING ((";
+            for (int i = 0; i <= boundary.numVerts; i++) {
+              std::string sep = (i == 0) ? "" : ", ";
+              int vertIndex = (i == boundary.numVerts) ? 0 : i;
+              str += StringUtil::Format("%s%f %f", sep,
+                                        radsToDegs(boundary.verts[vertIndex].lng),
+                                        radsToDegs(boundary.verts[vertIndex].lat));
+            }
+            str += "))";
+
+            return StringVector::AddString(result, str);
+          }
+        }
+      });
 }
 
 CreateScalarFunctionInfo H3Functions::GetDirectedEdgeToCellsFunction() {

--- a/src/h3_extension.cpp
+++ b/src/h3_extension.cpp
@@ -1,6 +1,8 @@
 #define DUCKDB_EXTENSION_MAIN
 #include "h3_extension.hpp"
 
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
 #include "duckdb/main/extension_util.hpp"
 #include "h3_functions.hpp"
 #include "h3api.h"

--- a/src/h3_hierarchy.cpp
+++ b/src/h3_hierarchy.cpp
@@ -83,6 +83,9 @@ static void CellToChildrenFunction(DataChunk &args, ExpressionState &state,
       }
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -130,6 +133,9 @@ static void CellToChildrenVarcharFunction(DataChunk &args,
         }
       }
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -661,19 +667,13 @@ CreateScalarFunctionInfo H3Functions::GetCellToChildrenFunction() {
   ScalarFunctionSet funcs("h3_cell_to_children");
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   CellToChildrenVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   CellToChildrenVarcharFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   CellToChildrenFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   CellToChildrenFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   CellToChildrenFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   CellToChildrenFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_hierarchy.cpp
+++ b/src/h3_hierarchy.cpp
@@ -661,13 +661,19 @@ CreateScalarFunctionInfo H3Functions::GetCellToChildrenFunction() {
   ScalarFunctionSet funcs("h3_cell_to_children");
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   CellToChildrenVarcharFunction));
+                                   CellToChildrenVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   CellToChildrenFunction));
+                                   CellToChildrenFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   CellToChildrenFunction));
+                                   CellToChildrenFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_hierarchy.cpp
+++ b/src/h3_hierarchy.cpp
@@ -662,17 +662,17 @@ CreateScalarFunctionInfo H3Functions::GetCellToChildrenFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::VARCHAR),
                                    CellToChildrenVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
                                    CellToChildrenFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
                                    CellToChildrenFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }

--- a/src/h3_hierarchy.cpp
+++ b/src/h3_hierarchy.cpp
@@ -345,11 +345,10 @@ static void CompactCellsFunction(DataChunk &args, ExpressionState &state,
     }
   }
 
-  result.Verify(args.size());
-
   if (lists.GetVectorType() == VectorType::CONSTANT_VECTOR) {
     result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
+  result.Verify(args.size());
 }
 
 static void CompactCellsVarcharFunction(DataChunk &args, ExpressionState &state,

--- a/src/h3_hierarchy.cpp
+++ b/src/h3_hierarchy.cpp
@@ -437,11 +437,10 @@ static void CompactCellsVarcharFunction(DataChunk &args, ExpressionState &state,
     }
   }
 
-  result.Verify(args.size());
-
   if (lists.GetVectorType() == VectorType::CONSTANT_VECTOR) {
     result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
+  result.Verify(args.size());
 }
 
 static void UncompactCellsFunction(DataChunk &args, ExpressionState &state,
@@ -531,11 +530,10 @@ static void UncompactCellsFunction(DataChunk &args, ExpressionState &state,
     }
   }
 
-  result.Verify(args.size());
-
   if (lhs.GetVectorType() == VectorType::CONSTANT_VECTOR) {
     result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
+  result.Verify(args.size());
 }
 
 static void UncompactCellsVarcharFunction(DataChunk &args,
@@ -644,11 +642,10 @@ static void UncompactCellsVarcharFunction(DataChunk &args,
     }
   }
 
-  result.Verify(args.size());
-
   if (lhs.GetVectorType() == VectorType::CONSTANT_VECTOR) {
     result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
+  result.Verify(args.size());
 }
 
 CreateScalarFunctionInfo H3Functions::GetCellToParentFunction() {

--- a/src/h3_indexing.cpp
+++ b/src/h3_indexing.cpp
@@ -202,8 +202,7 @@ struct CellToBoundaryOperator {
       }
       str += "))";
 
-      string_t strAsStr = string_t(strdup(str.c_str()), str.size());
-      return StringVector::AddString(result, strAsStr);
+      return StringVector::AddString(result, str);
     }
   }
 };

--- a/src/h3_indexing.cpp
+++ b/src/h3_indexing.cpp
@@ -129,6 +129,7 @@ static void CellToLngVarcharFunction(DataChunk &args, ExpressionState &state,
 
 static void CellToLatLngFunction(DataChunk &args, ExpressionState &state,
                                  Vector &result) {
+  result.SetVectorType(VectorType::FLAT_VECTOR);
   auto result_data = FlatVector::GetData<list_entry_t>(result);
   for (idx_t i = 0; i < args.size(); i++) {
     result_data[i].offset = ListVector::GetListSize(result);
@@ -289,17 +290,17 @@ CreateScalarFunctionInfo H3Functions::GetCellToLatLngFunction() {
                                    LogicalType::LIST(LogicalType::DOUBLE),
                                    CellToLatLngVarcharFunction, nullptr, nullptr, nullptr, nullptr,
                                    LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   FunctionStability::CONSISTENT));
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
                                    CellToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
                                    LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   FunctionStability::CONSISTENT));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
                                    CellToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
                                    LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   FunctionStability::CONSISTENT));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_indexing.cpp
+++ b/src/h3_indexing.cpp
@@ -147,6 +147,9 @@ static void CellToLatLngFunction(DataChunk &args, ExpressionState &state,
       result_data[i].length = 2;
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -178,6 +181,9 @@ static void CellToLatLngVarcharFunction(DataChunk &args, ExpressionState &state,
         result_data[i].length = 2;
       }
     }
+  }
+  if (args.AllConstant()) {
+  	result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -288,19 +294,13 @@ CreateScalarFunctionInfo H3Functions::GetCellToLatLngFunction() {
   ScalarFunctionSet funcs("h3_cell_to_latlng");
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   CellToLatLngVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::CONSISTENT));
+                                   CellToLatLngVarcharFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   CellToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::CONSISTENT));
+                                   CellToLatLngFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   CellToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::CONSISTENT));
+                                   CellToLatLngFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_indexing.cpp
+++ b/src/h3_indexing.cpp
@@ -181,58 +181,70 @@ static void CellToLatLngVarcharFunction(DataChunk &args, ExpressionState &state,
   result.Verify(args.size());
 }
 
-struct CellToBoundaryOperator {
-  template <class INPUT_TYPE, class RESULT_TYPE>
-  static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-    CellBoundary boundary;
-    H3Error err = cellToBoundary(input, &boundary);
-
-    if (err) {
-      // TODO: Is it possible to return null here instead?
-      return StringVector::EmptyString(result, 0);
-    } else {
-      std::string str = "POLYGON ((";
-      for (int i = 0; i <= boundary.numVerts; i++) {
-        std::string sep = (i == 0) ? "" : ", ";
-        // Add an extra vertex onto the end to close the polygon
-        int vertIndex = (i == boundary.numVerts) ? 0 : i;
-        str += StringUtil::Format("%s%f %f", sep,
-                                  radsToDegs(boundary.verts[vertIndex].lng),
-                                  radsToDegs(boundary.verts[vertIndex].lat));
-      }
-      str += "))";
-
-      return StringVector::AddString(result, str);
-    }
-  }
-};
-
 static void CellToBoundaryWktFunction(DataChunk &args, ExpressionState &state,
                                       Vector &result) {
-  UnaryExecutor::ExecuteString<uint64_t, string_t, CellToBoundaryOperator>(
-      args.data[0], result, args.size());
-}
+  auto &inputs = args.data[0];
+  UnaryExecutor::ExecuteWithNulls<uint64_t, string_t>(
+      inputs, result, args.size(),
+      [&](uint64_t input, ValidityMask &mask, idx_t idx) {
+        CellBoundary boundary;
+        H3Error err = cellToBoundary(input, &boundary);
 
-struct CellToBoundaryVarcharOperator {
-  template <class INPUT_TYPE, class RESULT_TYPE>
-  static RESULT_TYPE Operation(INPUT_TYPE input, Vector &result) {
-    H3Index h;
-    H3Error err = stringToH3(input.GetString().c_str(), &h);
-    if (err) {
-      return StringVector::EmptyString(result, 0);
-    } else {
-      return CellToBoundaryOperator().Operation<H3Index, RESULT_TYPE>(h,
-                                                                      result);
-    }
-  }
-};
+        if (err) {
+          mask.SetInvalid(idx);
+          return StringVector::EmptyString(result, 0);
+        } else {
+          std::string str = "POLYGON ((";
+          for (int i = 0; i <= boundary.numVerts; i++) {
+            std::string sep = (i == 0) ? "" : ", ";
+            // Add an extra vertex onto the end to close the polygon
+            int vertIndex = (i == boundary.numVerts) ? 0 : i;
+            str += StringUtil::Format("%s%f %f", sep,
+                                      radsToDegs(boundary.verts[vertIndex].lng),
+                                      radsToDegs(boundary.verts[vertIndex].lat));
+          }
+          str += "))";
+
+          return StringVector::AddString(result, str);
+        }
+      });
+}
 
 static void CellToBoundaryWktVarcharFunction(DataChunk &args,
                                              ExpressionState &state,
                                              Vector &result) {
-  UnaryExecutor::ExecuteString<string_t, string_t,
-                               CellToBoundaryVarcharOperator>(
-      args.data[0], result, args.size());
+  auto &inputs = args.data[0];
+  UnaryExecutor::ExecuteWithNulls<string_t, string_t>(
+      inputs, result, args.size(),
+      [&](string_t input, ValidityMask &mask, idx_t idx) {
+        H3Index h;
+        H3Error err = stringToH3(input.GetString().c_str(), &h);
+        if (err) {
+          mask.SetInvalid(idx);
+          return StringVector::EmptyString(result, 0);
+        } else {
+          CellBoundary boundary;
+          H3Error err = cellToBoundary(h, &boundary);
+
+          if (err) {
+            mask.SetInvalid(idx);
+            return StringVector::EmptyString(result, 0);
+          } else {
+            std::string str = "POLYGON ((";
+            for (int i = 0; i <= boundary.numVerts; i++) {
+              std::string sep = (i == 0) ? "" : ", ";
+              // Add an extra vertex onto the end to close the polygon
+              int vertIndex = (i == boundary.numVerts) ? 0 : i;
+              str += StringUtil::Format("%s%f %f", sep,
+                                        radsToDegs(boundary.verts[vertIndex].lng),
+                                        radsToDegs(boundary.verts[vertIndex].lat));
+            }
+            str += "))";
+
+            return StringVector::AddString(result, str);
+          }
+        }
+      });
 }
 
 CreateScalarFunctionInfo H3Functions::GetLatLngToCellFunction() {

--- a/src/h3_indexing.cpp
+++ b/src/h3_indexing.cpp
@@ -276,13 +276,19 @@ CreateScalarFunctionInfo H3Functions::GetCellToLatLngFunction() {
   ScalarFunctionSet funcs("h3_cell_to_latlng");
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   CellToLatLngVarcharFunction));
+                                   CellToLatLngVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   CellToLatLngFunction));
+                                   CellToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   CellToLatLngFunction));
+                                   CellToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_indexing.cpp
+++ b/src/h3_indexing.cpp
@@ -288,17 +288,17 @@ CreateScalarFunctionInfo H3Functions::GetCellToLatLngFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::DOUBLE),
                                    CellToLatLngVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
                                    CellToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
                                    CellToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }

--- a/src/h3_indexing.cpp
+++ b/src/h3_indexing.cpp
@@ -183,7 +183,7 @@ static void CellToLatLngVarcharFunction(DataChunk &args, ExpressionState &state,
     }
   }
   if (args.AllConstant()) {
-  	result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }

--- a/src/h3_inspection.cpp
+++ b/src/h3_inspection.cpp
@@ -191,6 +191,9 @@ static void GetIcosahedronFacesFunction(DataChunk &args, ExpressionState &state,
 
     result_data[i].length = actual;
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -235,6 +238,9 @@ static void GetIcosahedronFacesVarcharFunction(DataChunk &args,
     }
 
     result_data[i].length = actual;
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -313,19 +319,13 @@ CreateScalarFunctionInfo H3Functions::GetGetIcosahedronFacesFunction() {
   ScalarFunctionSet funcs("h3_get_icosahedron_faces");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   GetIcosahedronFacesFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GetIcosahedronFacesFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   GetIcosahedronFacesFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GetIcosahedronFacesFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   GetIcosahedronFacesVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GetIcosahedronFacesVarcharFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_inspection.cpp
+++ b/src/h3_inspection.cpp
@@ -314,17 +314,17 @@ CreateScalarFunctionInfo H3Functions::GetGetIcosahedronFacesFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
                                    GetIcosahedronFacesFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
                                    GetIcosahedronFacesFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::INTEGER),
                                    GetIcosahedronFacesVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }

--- a/src/h3_inspection.cpp
+++ b/src/h3_inspection.cpp
@@ -313,13 +313,19 @@ CreateScalarFunctionInfo H3Functions::GetGetIcosahedronFacesFunction() {
   ScalarFunctionSet funcs("h3_get_icosahedron_faces");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   GetIcosahedronFacesFunction));
+                                   GetIcosahedronFacesFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   GetIcosahedronFacesFunction));
+                                   GetIcosahedronFacesFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   GetIcosahedronFacesVarcharFunction));
+                                   GetIcosahedronFacesVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_misc.cpp
+++ b/src/h3_misc.cpp
@@ -250,6 +250,9 @@ static void GetPentagonsFunction(DataChunk &args, ExpressionState &state,
       result_data[i].length = actual;
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -284,6 +287,9 @@ static void GetPentagonsVarcharFunction(DataChunk &args, ExpressionState &state,
 
       result_data[i].length = actual;
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -335,6 +341,10 @@ static void GreatCircleDistanceFunction(DataChunk &args, ExpressionState &state,
       result.SetValue(i, Value(LogicalType::SQLNULL));
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
+  result.Verify(args.size());
 }
 
 CreateScalarFunctionInfo H3Functions::GetGetHexagonAreaAvgFunction() {
@@ -395,17 +405,13 @@ CreateScalarFunctionInfo H3Functions::GetGetRes0CellsVarcharFunction() {
 CreateScalarFunctionInfo H3Functions::GetGetPentagonsFunction() {
   return CreateScalarFunctionInfo(ScalarFunction(
       "h3_get_pentagons", {LogicalType::INTEGER},
-      LogicalType::LIST(LogicalType::UBIGINT), GetPentagonsFunction, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      LogicalType::LIST(LogicalType::UBIGINT), GetPentagonsFunction));
 }
 
 CreateScalarFunctionInfo H3Functions::GetGetPentagonsVarcharFunction() {
   return CreateScalarFunctionInfo(ScalarFunction(
       "h3_get_pentagons_string", {LogicalType::INTEGER},
-      LogicalType::LIST(LogicalType::VARCHAR), GetPentagonsVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      LogicalType::LIST(LogicalType::VARCHAR), GetPentagonsVarcharFunction));
 }
 
 CreateScalarFunctionInfo H3Functions::GetGreatCircleDistanceFunction() {
@@ -413,9 +419,7 @@ CreateScalarFunctionInfo H3Functions::GetGreatCircleDistanceFunction() {
       "h3_great_circle_distance",
       {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE,
        LogicalType::DOUBLE, LogicalType::VARCHAR},
-      LogicalType::DOUBLE, GreatCircleDistanceFunction, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      LogicalType::DOUBLE, GreatCircleDistanceFunction));
 }
 
 } // namespace duckdb

--- a/src/h3_misc.cpp
+++ b/src/h3_misc.cpp
@@ -290,8 +290,6 @@ static void GetPentagonsVarcharFunction(DataChunk &args, ExpressionState &state,
 
 static void GreatCircleDistanceFunction(DataChunk &args, ExpressionState &state,
                                         Vector &result) {
-  auto result_data = FlatVector::GetData<list_entry_t>(result);
-
   UnifiedVectorFormat unitData;
 
   args.data[4].ToUnifiedFormat(args.size(), unitData);

--- a/src/h3_misc.cpp
+++ b/src/h3_misc.cpp
@@ -396,7 +396,7 @@ CreateScalarFunctionInfo H3Functions::GetGetPentagonsFunction() {
   return CreateScalarFunctionInfo(ScalarFunction(
       "h3_get_pentagons", {LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::UBIGINT), GetPentagonsFunction, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
 }
 
@@ -404,7 +404,7 @@ CreateScalarFunctionInfo H3Functions::GetGetPentagonsVarcharFunction() {
   return CreateScalarFunctionInfo(ScalarFunction(
       "h3_get_pentagons_string", {LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::VARCHAR), GetPentagonsVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
 }
 
@@ -414,7 +414,7 @@ CreateScalarFunctionInfo H3Functions::GetGreatCircleDistanceFunction() {
       {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE,
        LogicalType::DOUBLE, LogicalType::VARCHAR},
       LogicalType::DOUBLE, GreatCircleDistanceFunction, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
 }
 

--- a/src/h3_misc.cpp
+++ b/src/h3_misc.cpp
@@ -397,13 +397,17 @@ CreateScalarFunctionInfo H3Functions::GetGetRes0CellsVarcharFunction() {
 CreateScalarFunctionInfo H3Functions::GetGetPentagonsFunction() {
   return CreateScalarFunctionInfo(ScalarFunction(
       "h3_get_pentagons", {LogicalType::INTEGER},
-      LogicalType::LIST(LogicalType::UBIGINT), GetPentagonsFunction));
+      LogicalType::LIST(LogicalType::UBIGINT), GetPentagonsFunction, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
 }
 
 CreateScalarFunctionInfo H3Functions::GetGetPentagonsVarcharFunction() {
   return CreateScalarFunctionInfo(ScalarFunction(
       "h3_get_pentagons_string", {LogicalType::INTEGER},
-      LogicalType::LIST(LogicalType::VARCHAR), GetPentagonsVarcharFunction));
+      LogicalType::LIST(LogicalType::VARCHAR), GetPentagonsVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
 }
 
 CreateScalarFunctionInfo H3Functions::GetGreatCircleDistanceFunction() {
@@ -411,7 +415,9 @@ CreateScalarFunctionInfo H3Functions::GetGreatCircleDistanceFunction() {
       "h3_great_circle_distance",
       {LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE,
        LogicalType::DOUBLE, LogicalType::VARCHAR},
-      LogicalType::DOUBLE, GreatCircleDistanceFunction));
+      LogicalType::DOUBLE, GreatCircleDistanceFunction, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
 }
 
 } // namespace duckdb

--- a/src/h3_misc.cpp
+++ b/src/h3_misc.cpp
@@ -183,8 +183,8 @@ static void GetRes0CellsFunction(DataChunk &args, ExpressionState &state,
       result_data[i].length = actual;
     }
   }
-  result.Verify(args.size());
   result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  result.Verify(args.size());
 }
 
 static void GetRes0CellsVarcharFunction(DataChunk &args, ExpressionState &state,
@@ -216,8 +216,8 @@ static void GetRes0CellsVarcharFunction(DataChunk &args, ExpressionState &state,
       result_data[i].length = actual;
     }
   }
-  result.Verify(args.size());
   result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  result.Verify(args.size());
 }
 
 static void GetPentagonsFunction(DataChunk &args, ExpressionState &state,

--- a/src/h3_regions.cpp
+++ b/src/h3_regions.cpp
@@ -138,7 +138,6 @@ static void CellsToMultiPolygonWktFunction(DataChunk &args,
   }
 
   result.Verify(args.size());
-
   if (lhs.GetVectorType() == VectorType::CONSTANT_VECTOR) {
     result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }

--- a/src/h3_regions.cpp
+++ b/src/h3_regions.cpp
@@ -137,10 +137,10 @@ static void CellsToMultiPolygonWktFunction(DataChunk &args,
     }
   }
 
-  result.Verify(args.size());
   if (lhs.GetVectorType() == VectorType::CONSTANT_VECTOR) {
     result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
+  result.Verify(args.size());
 }
 
 static size_t whitespace(const std::string &str, size_t offset) {

--- a/src/h3_traversal.cpp
+++ b/src/h3_traversal.cpp
@@ -634,18 +634,18 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
                                    GridDiskTmplFunction<GridDiskOperator>, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
                                    GridDiskTmplFunction<GridDiskOperator>, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(
       ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::VARCHAR),
                      GridDiskTmplVarcharFunction<GridDiskOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType(LogicalTypeId::INVALID),
+                     LogicalType::INVALID,
                      FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
@@ -656,19 +656,19 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskDistancesFunction() {
       ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT)),
                      GridDiskDistancesTmplFunction<GridDiskDistancesOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType(LogicalTypeId::INVALID),
+                     LogicalType::INVALID,
                      FunctionStability::VOLATILE));
   funcs.AddFunction(
       ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::LIST(LogicalType::BIGINT)),
                      GridDiskDistancesTmplFunction<GridDiskDistancesOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType(LogicalTypeId::INVALID),
+                     LogicalType::INVALID,
                      FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::VARCHAR, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)),
       GridDiskDistancesTmplVarcharFunction<GridDiskDistancesOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
@@ -679,19 +679,19 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskUnsafeFunction() {
       ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::UBIGINT),
                      GridDiskTmplFunction<GridDiskUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType(LogicalTypeId::INVALID),
+                     LogicalType::INVALID,
                      FunctionStability::VOLATILE));
   funcs.AddFunction(
       ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::BIGINT),
                      GridDiskTmplFunction<GridDiskUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType(LogicalTypeId::INVALID),
+                     LogicalType::INVALID,
                      FunctionStability::VOLATILE));
   funcs.AddFunction(
       ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::VARCHAR),
                      GridDiskTmplVarcharFunction<GridDiskUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType(LogicalTypeId::INVALID),
+                     LogicalType::INVALID,
                      FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
@@ -702,19 +702,19 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskDistancesUnsafeFunction() {
       {LogicalType::UBIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT)),
       GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::BIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::BIGINT)),
       GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::VARCHAR, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)),
       GridDiskDistancesTmplVarcharFunction<GridDiskDistancesUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
@@ -725,19 +725,19 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskDistancesSafeFunction() {
       {LogicalType::UBIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT)),
       GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::BIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::BIGINT)),
       GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::VARCHAR, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)),
       GridDiskDistancesTmplVarcharFunction<GridDiskDistancesSafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType(LogicalTypeId::INVALID),
+      LogicalType::INVALID,
       FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
@@ -747,17 +747,17 @@ CreateScalarFunctionInfo H3Functions::GetGridRingFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
                                    GridRingFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
                                    GridRingFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::VARCHAR),
                                    GridRingVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
@@ -767,17 +767,17 @@ CreateScalarFunctionInfo H3Functions::GetGridRingUnsafeFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
                                    GridRingUnsafeFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
                                    GridRingUnsafeFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::VARCHAR),
                                    GridRingUnsafeVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
@@ -787,17 +787,17 @@ CreateScalarFunctionInfo H3Functions::GetGridPathCellsFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
                                    GridPathCellsFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::BIGINT),
                                    GridPathCellsFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
                                    GridPathCellsVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
@@ -819,17 +819,17 @@ CreateScalarFunctionInfo H3Functions::GetCellToLocalIjFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
                                    CellToLocalIjFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
                                    CellToLocalIjFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
                                    CellToLocalIjVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }

--- a/src/h3_traversal.cpp
+++ b/src/h3_traversal.cpp
@@ -50,6 +50,9 @@ static void GridDiskTmplFunction(DataChunk &args, ExpressionState &state,
       }
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -96,6 +99,9 @@ static void GridDiskTmplVarcharFunction(DataChunk &args, ExpressionState &state,
         }
       }
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -165,6 +171,9 @@ static void GridDiskDistancesTmplFunction(DataChunk &args,
       }
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -222,6 +231,9 @@ static void GridDiskDistancesTmplVarcharFunction(DataChunk &args,
       }
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -258,6 +270,9 @@ static void GridRingFunction(DataChunk &args, ExpressionState &state,
         result_data[i].length = actual;
       }
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -304,6 +319,9 @@ static void GridRingVarcharFunction(DataChunk &args, ExpressionState &state,
       }
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -335,6 +353,9 @@ static void GridRingUnsafeFunction(DataChunk &args, ExpressionState &state,
 
       result_data[i].length = actual;
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -377,6 +398,9 @@ static void GridRingUnsafeVarcharFunction(DataChunk &args,
       }
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -414,6 +438,9 @@ static void GridPathCellsFunction(DataChunk &args, ExpressionState &state,
         result_data[i].length = actual;
       }
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -462,6 +489,9 @@ static void GridPathCellsVarcharFunction(DataChunk &args,
         }
       }
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -537,6 +567,9 @@ static void CellToLocalIjFunction(DataChunk &args, ExpressionState &state,
       result_data[i].length = 2;
     }
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -571,6 +604,9 @@ static void CellToLocalIjVarcharFunction(DataChunk &args,
         result_data[i].length = 2;
       }
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -633,20 +669,14 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskFunction() {
   ScalarFunctionSet funcs("h3_grid_disk");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   GridDiskTmplFunction<GridDiskOperator>, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridDiskTmplFunction<GridDiskOperator>));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   GridDiskTmplFunction<GridDiskOperator>, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridDiskTmplFunction<GridDiskOperator>));
   funcs.AddFunction(
       ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::VARCHAR),
-                     GridDiskTmplVarcharFunction<GridDiskOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType::INVALID,
-                     FunctionStability::VOLATILE));
+                     GridDiskTmplVarcharFunction<GridDiskOperator>));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -655,21 +685,15 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskDistancesFunction() {
   funcs.AddFunction(
       ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT)),
-                     GridDiskDistancesTmplFunction<GridDiskDistancesOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType::INVALID,
-                     FunctionStability::VOLATILE));
+                     GridDiskDistancesTmplFunction<GridDiskDistancesOperator>));
   funcs.AddFunction(
       ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::LIST(LogicalType::BIGINT)),
-                     GridDiskDistancesTmplFunction<GridDiskDistancesOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType::INVALID,
-                     FunctionStability::VOLATILE));
+                     GridDiskDistancesTmplFunction<GridDiskDistancesOperator>));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::VARCHAR, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)),
-      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesOperator>));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -678,21 +702,15 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskUnsafeFunction() {
   funcs.AddFunction(
       ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::UBIGINT),
-                     GridDiskTmplFunction<GridDiskUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType::INVALID,
-                     FunctionStability::VOLATILE));
+                     GridDiskTmplFunction<GridDiskUnsafeOperator>));
   funcs.AddFunction(
       ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::BIGINT),
-                     GridDiskTmplFunction<GridDiskUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType::INVALID,
-                     FunctionStability::VOLATILE));
+                     GridDiskTmplFunction<GridDiskUnsafeOperator>));
   funcs.AddFunction(
       ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::VARCHAR),
-                     GridDiskTmplVarcharFunction<GridDiskUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-                     LogicalType::INVALID,
-                     FunctionStability::VOLATILE));
+                     GridDiskTmplVarcharFunction<GridDiskUnsafeOperator>));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -701,21 +719,15 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskDistancesUnsafeFunction() {
   funcs.AddFunction(ScalarFunction(
       {LogicalType::UBIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT)),
-      GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::BIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::BIGINT)),
-      GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::VARCHAR, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)),
-      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesUnsafeOperator>));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -724,21 +736,15 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskDistancesSafeFunction() {
   funcs.AddFunction(ScalarFunction(
       {LogicalType::UBIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT)),
-      GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::BIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::BIGINT)),
-      GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::VARCHAR, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)),
-      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesSafeOperator>, nullptr, nullptr, nullptr, nullptr,
-      LogicalType::INVALID,
-      FunctionStability::VOLATILE));
+      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesSafeOperator>));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -746,19 +752,13 @@ CreateScalarFunctionInfo H3Functions::GetGridRingFunction() {
   ScalarFunctionSet funcs("h3_grid_ring");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   GridRingFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridRingFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   GridRingFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridRingFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   GridRingVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridRingVarcharFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -766,19 +766,13 @@ CreateScalarFunctionInfo H3Functions::GetGridRingUnsafeFunction() {
   ScalarFunctionSet funcs("h3_grid_ring_unsafe");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   GridRingUnsafeFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridRingUnsafeFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   GridRingUnsafeFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridRingUnsafeFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   GridRingUnsafeVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridRingUnsafeVarcharFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -786,19 +780,13 @@ CreateScalarFunctionInfo H3Functions::GetGridPathCellsFunction() {
   ScalarFunctionSet funcs("h3_grid_path_cells");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   GridPathCellsFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridPathCellsFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   GridPathCellsFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridPathCellsFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   GridPathCellsVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   GridPathCellsVarcharFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -818,19 +806,13 @@ CreateScalarFunctionInfo H3Functions::GetCellToLocalIjFunction() {
   ScalarFunctionSet funcs("h3_cell_to_local_ij");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   CellToLocalIjFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   CellToLocalIjFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   CellToLocalIjFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   CellToLocalIjFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   CellToLocalIjVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   CellToLocalIjVarcharFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_traversal.cpp
+++ b/src/h3_traversal.cpp
@@ -633,14 +633,20 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskFunction() {
   ScalarFunctionSet funcs("h3_grid_disk");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   GridDiskTmplFunction<GridDiskOperator>));
+                                   GridDiskTmplFunction<GridDiskOperator>, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   GridDiskTmplFunction<GridDiskOperator>));
+                                   GridDiskTmplFunction<GridDiskOperator>, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(
       ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::VARCHAR),
-                     GridDiskTmplVarcharFunction<GridDiskOperator>));
+                     GridDiskTmplVarcharFunction<GridDiskOperator>, nullptr, nullptr, nullptr, nullptr,
+                     LogicalType(LogicalTypeId::INVALID),
+                     FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -649,15 +655,21 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskDistancesFunction() {
   funcs.AddFunction(
       ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT)),
-                     GridDiskDistancesTmplFunction<GridDiskDistancesOperator>));
+                     GridDiskDistancesTmplFunction<GridDiskDistancesOperator>, nullptr, nullptr, nullptr, nullptr,
+                     LogicalType(LogicalTypeId::INVALID),
+                     FunctionStability::VOLATILE));
   funcs.AddFunction(
       ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::LIST(LogicalType::BIGINT)),
-                     GridDiskDistancesTmplFunction<GridDiskDistancesOperator>));
+                     GridDiskDistancesTmplFunction<GridDiskDistancesOperator>, nullptr, nullptr, nullptr, nullptr,
+                     LogicalType(LogicalTypeId::INVALID),
+                     FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::VARCHAR, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)),
-      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesOperator>));
+      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesOperator>, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -666,15 +678,21 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskUnsafeFunction() {
   funcs.AddFunction(
       ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::UBIGINT),
-                     GridDiskTmplFunction<GridDiskUnsafeOperator>));
+                     GridDiskTmplFunction<GridDiskUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
+                     LogicalType(LogicalTypeId::INVALID),
+                     FunctionStability::VOLATILE));
   funcs.AddFunction(
       ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::BIGINT),
-                     GridDiskTmplFunction<GridDiskUnsafeOperator>));
+                     GridDiskTmplFunction<GridDiskUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
+                     LogicalType(LogicalTypeId::INVALID),
+                     FunctionStability::VOLATILE));
   funcs.AddFunction(
       ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                      LogicalType::LIST(LogicalType::VARCHAR),
-                     GridDiskTmplVarcharFunction<GridDiskUnsafeOperator>));
+                     GridDiskTmplVarcharFunction<GridDiskUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
+                     LogicalType(LogicalTypeId::INVALID),
+                     FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -683,15 +701,21 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskDistancesUnsafeFunction() {
   funcs.AddFunction(ScalarFunction(
       {LogicalType::UBIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT)),
-      GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>));
+      GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::BIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::BIGINT)),
-      GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>));
+      GridDiskDistancesTmplFunction<GridDiskDistancesUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::VARCHAR, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)),
-      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesUnsafeOperator>));
+      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesUnsafeOperator>, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -700,15 +724,21 @@ CreateScalarFunctionInfo H3Functions::GetGridDiskDistancesSafeFunction() {
   funcs.AddFunction(ScalarFunction(
       {LogicalType::UBIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::UBIGINT)),
-      GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>));
+      GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::BIGINT, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::BIGINT)),
-      GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>));
+      GridDiskDistancesTmplFunction<GridDiskDistancesSafeOperator>, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction(
       {LogicalType::VARCHAR, LogicalType::INTEGER},
       LogicalType::LIST(LogicalType::LIST(LogicalType::VARCHAR)),
-      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesSafeOperator>));
+      GridDiskDistancesTmplVarcharFunction<GridDiskDistancesSafeOperator>, nullptr, nullptr, nullptr, nullptr,
+      LogicalType(LogicalTypeId::INVALID),
+      FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -716,13 +746,19 @@ CreateScalarFunctionInfo H3Functions::GetGridRingFunction() {
   ScalarFunctionSet funcs("h3_grid_ring");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   GridRingFunction));
+                                   GridRingFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   GridRingFunction));
+                                   GridRingFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   GridRingVarcharFunction));
+                                   GridRingVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -730,13 +766,19 @@ CreateScalarFunctionInfo H3Functions::GetGridRingUnsafeFunction() {
   ScalarFunctionSet funcs("h3_grid_ring_unsafe");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   GridRingUnsafeFunction));
+                                   GridRingUnsafeFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   GridRingUnsafeFunction));
+                                   GridRingUnsafeFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::INTEGER},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   GridRingUnsafeVarcharFunction));
+                                   GridRingUnsafeVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -744,13 +786,19 @@ CreateScalarFunctionInfo H3Functions::GetGridPathCellsFunction() {
   ScalarFunctionSet funcs("h3_grid_path_cells");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::UBIGINT),
-                                   GridPathCellsFunction));
+                                   GridPathCellsFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::BIGINT),
-                                   GridPathCellsFunction));
+                                   GridPathCellsFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   GridPathCellsVarcharFunction));
+                                   GridPathCellsVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 
@@ -770,13 +818,19 @@ CreateScalarFunctionInfo H3Functions::GetCellToLocalIjFunction() {
   ScalarFunctionSet funcs("h3_cell_to_local_ij");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT, LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   CellToLocalIjFunction));
+                                   CellToLocalIjFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT, LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::INTEGER),
-                                   CellToLocalIjFunction));
+                                   CellToLocalIjFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR, LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::VARCHAR),
-                                   CellToLocalIjVarcharFunction));
+                                   CellToLocalIjVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_vertex.cpp
+++ b/src/h3_vertex.cpp
@@ -81,11 +81,11 @@ static void CellToVertexesFunction(DataChunk &args, ExpressionState &state,
     }
     offset += actual;
   }
-  result.Verify(args.size());
 
   if (args.AllConstant()) {
     result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
+  result.Verify(args.size());
 }
 
 static void CellToVertexesVarcharFunction(DataChunk &args,
@@ -129,11 +129,11 @@ static void CellToVertexesVarcharFunction(DataChunk &args,
       offset += actual;
     }
   }
-  result.Verify(args.size());
 
   if (args.AllConstant()) {
     result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
+  result.Verify(args.size());
 }
 
 static void VertexToLatFunction(DataChunk &args, ExpressionState &state,

--- a/src/h3_vertex.cpp
+++ b/src/h3_vertex.cpp
@@ -235,6 +235,9 @@ static void VertexToLatLngFunction(DataChunk &args, ExpressionState &state,
     ListVector::PushBack(result, radsToDegs(latLng.lng));
     result_data[i].length = 2;
   }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
+  }
   result.Verify(args.size());
 }
 
@@ -263,6 +266,9 @@ static void VertexToLatLngVarcharFunction(DataChunk &args,
         result_data[i].length = 2;
       }
     }
+  }
+  if (args.AllConstant()) {
+    result.SetVectorType(VectorType::CONSTANT_VECTOR);
   }
   result.Verify(args.size());
 }
@@ -342,19 +348,13 @@ CreateScalarFunctionInfo H3Functions::GetVertexToLatLngFunction() {
   ScalarFunctionSet funcs("h3_vertex_to_latlng");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   VertexToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   VertexToLatLngFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   VertexToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   VertexToLatLngFunction));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   VertexToLatLngVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType::INVALID,
-                                   FunctionStability::VOLATILE));
+                                   VertexToLatLngVarcharFunction));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/h3_vertex.cpp
+++ b/src/h3_vertex.cpp
@@ -343,17 +343,17 @@ CreateScalarFunctionInfo H3Functions::GetVertexToLatLngFunction() {
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
                                    VertexToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
                                    VertexToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::DOUBLE),
                                    VertexToLatLngVarcharFunction, nullptr, nullptr, nullptr, nullptr,
-                                   LogicalType(LogicalTypeId::INVALID),
+                                   LogicalType::INVALID,
                                    FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }

--- a/src/h3_vertex.cpp
+++ b/src/h3_vertex.cpp
@@ -342,13 +342,19 @@ CreateScalarFunctionInfo H3Functions::GetVertexToLatLngFunction() {
   ScalarFunctionSet funcs("h3_vertex_to_latlng");
   funcs.AddFunction(ScalarFunction({LogicalType::UBIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   VertexToLatLngFunction));
+                                   VertexToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::BIGINT},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   VertexToLatLngFunction));
+                                   VertexToLatLngFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   funcs.AddFunction(ScalarFunction({LogicalType::VARCHAR},
                                    LogicalType::LIST(LogicalType::DOUBLE),
-                                   VertexToLatLngVarcharFunction));
+                                   VertexToLatLngVarcharFunction, nullptr, nullptr, nullptr, nullptr,
+                                   LogicalType(LogicalTypeId::INVALID),
+                                   FunctionStability::VOLATILE));
   return CreateScalarFunctionInfo(funcs);
 }
 

--- a/src/include/h3_common.hpp
+++ b/src/include/h3_common.hpp
@@ -8,11 +8,6 @@
 
 #pragma once
 
-#include "duckdb/common/operator/cast_operators.hpp"
-#include "duckdb/common/operator/decimal_cast_operators.hpp"
-#include "duckdb/common/operator/string_cast.hpp"
-#include "duckdb/execution/expression_executor.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "h3api.h"
 
 namespace duckdb {

--- a/src/include/h3_extension.hpp
+++ b/src/include/h3_extension.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "duckdb.hpp"
+#include "duckdb/main/extension.hpp"
 
 namespace duckdb {
 

--- a/test/sql/h3/h3_functions_directededge.test
+++ b/test/sql/h3/h3_functions_directededge.test
@@ -106,17 +106,17 @@ false
 query I
 SELECT h3_directed_edge_to_boundary_wkt(0::ubigint)
 ----
-NULL
+(empty)
 
 query I
 SELECT h3_directed_edge_to_boundary_wkt(0::bigint)
 ----
-NULL
+(empty)
 
 query I
 SELECT h3_directed_edge_to_boundary_wkt('0')
 ----
-NULL
+(empty)
 
 query I
 SELECT h3_directed_edge_to_boundary_wkt(1608492358964346879::ubigint)

--- a/test/sql/h3/h3_functions_directededge.test
+++ b/test/sql/h3/h3_functions_directededge.test
@@ -104,19 +104,19 @@ SELECT h3_are_neighbor_cells(599686042433355775::bigint, 599686029548453887::big
 false
 
 query I
-SELECT strlen(h3_directed_edge_to_boundary_wkt(0::ubigint))
+SELECT h3_directed_edge_to_boundary_wkt(0::ubigint)
 ----
-0
+NULL
 
 query I
-SELECT strlen(h3_directed_edge_to_boundary_wkt(0::bigint))
+SELECT h3_directed_edge_to_boundary_wkt(0::bigint)
 ----
-0
+NULL
 
 query I
-SELECT strlen(h3_directed_edge_to_boundary_wkt('0'))
+SELECT h3_directed_edge_to_boundary_wkt('0')
 ----
-0
+NULL
 
 query I
 SELECT h3_directed_edge_to_boundary_wkt(1608492358964346879::ubigint)

--- a/test/sql/h3/h3_functions_indexing.test
+++ b/test/sql/h3/h3_functions_indexing.test
@@ -96,7 +96,7 @@ POLYGON ((38.777546 44.198571, 39.938746 42.736298, 42.150674 42.631271, 43.2583
 query I
 SELECT h3_cell_to_boundary_wkt(h3_string_to_h3('fffffffffffffff'));
 ----
-NULL
+(empty)
 
 query I
 SELECT h3_cell_to_boundary_wkt('822d57fffffffff');
@@ -106,4 +106,4 @@ POLYGON ((38.777546 44.198571, 39.938746 42.736298, 42.150674 42.631271, 43.2583
 query I
 SELECT h3_cell_to_boundary_wkt('zzz');
 ----
-NULL
+(empty)

--- a/test/sql/h3/h3_functions_indexing.test
+++ b/test/sql/h3/h3_functions_indexing.test
@@ -94,9 +94,9 @@ SELECT h3_cell_to_boundary_wkt(cast(h3_string_to_h3('822d57fffffffff') as bigint
 POLYGON ((38.777546 44.198571, 39.938746 42.736298, 42.150674 42.631271, 43.258395 44.047542, 42.146575 45.539505, 39.897167 45.559577, 38.777546 44.198571))
 
 query I
-SELECT strlen(h3_cell_to_boundary_wkt(h3_string_to_h3('fffffffffffffff')));
+SELECT h3_cell_to_boundary_wkt(h3_string_to_h3('fffffffffffffff'));
 ----
-0
+NULL
 
 query I
 SELECT h3_cell_to_boundary_wkt('822d57fffffffff');
@@ -104,6 +104,6 @@ SELECT h3_cell_to_boundary_wkt('822d57fffffffff');
 POLYGON ((38.777546 44.198571, 39.938746 42.736298, 42.150674 42.631271, 43.258395 44.047542, 42.146575 45.539505, 39.897167 45.559577, 38.777546 44.198571))
 
 query I
-SELECT strlen(h3_cell_to_boundary_wkt('zzz'));
+SELECT h3_cell_to_boundary_wkt('zzz');
 ----
-0
+NULL


### PR DESCRIPTION
A few of the functions did not set the vector type to `constant` when all input arguments where constants. This lead to test errors when running the tests in debug mode, or when having `D_ASSERTS` enabled.
This adds the necessary `result.SetVectorType(VectorType::CONSTANT_VECTOR);` calls wherever necessary.