### PR TITLE
Add missing include for cassert

### DIFF
--- a/src/well_known_encoder.cpp
+++ b/src/well_known_encoder.cpp
@@ -2,6 +2,7 @@
 #include "well_known_encoder.hpp"
 #include "h3api.h"
 #include "duckdb/common/string_util.hpp"
+#include <cassert>
 
 namespace duckdb {
 


### PR DESCRIPTION
This wouldn't compile on my machine without this include, due to the
usages of the assert function.
